### PR TITLE
feat: add an option to overwrite the event with the validation result

### DIFF
--- a/packages/middy-zod-validator/README.md
+++ b/packages/middy-zod-validator/README.md
@@ -105,6 +105,25 @@ export const lambdaFunction: Handler<Event> = async (event) => {
 
 This way your lambda is secure at runtime and compile time!
 
+You can optionally overwrite the whole event with the result of the validation. This way you can apply defaults to values.  
+Remember to add `.passthrough()` to the objects if you want to retain any undeclared data
+
+```ts
+export const eventSchema = z.object({
+  body: z
+    .object({
+      HelloWorld: z.string().default("Hello!"),
+    }).default({}),
+}).passthrough();
+
+export const handler = middy(lambdaFunction).use(
+  zodValidator({
+    eventSchema,
+    overwriteEvent: true,
+  })
+);
+```
+
 ## Contribution
 
 If there is an option or feature you would like to see, please feel free to raise an issue or open a pull request. Contributions are welcome :)

--- a/packages/middy-zod-validator/src/index.test.ts
+++ b/packages/middy-zod-validator/src/index.test.ts
@@ -61,4 +61,19 @@ describe("When the zodValidator is called", () => {
       body: JSON.stringify(error),
     });
   });
+
+
+  it("should overwrite when the appropriate option is set", async () => {
+    const input = {
+      eventSchema: { safeParse: jest.fn().mockReturnValue({ success: true, data: { my: "event" } }) } as unknown as ZodSchema,
+      overwriteEvent: true,
+    };
+    const result = zodValidator(input);
+
+    const beforeInput = { event: "MOCK_EVENT", context: "MOCK_CONTEXT" };
+    await result.before(beforeInput);
+
+    expect(input.eventSchema.safeParse).toHaveBeenCalledWith("MOCK_EVENT");
+    expect(beforeInput.event).toEqual( { my: "event" });
+  });
 });

--- a/packages/middy-zod-validator/src/index.ts
+++ b/packages/middy-zod-validator/src/index.ts
@@ -10,6 +10,7 @@ type Inputs = {
   contextSchema?: ZodSchema;
   envSchema?: ZodSchema;
   logger?: any;
+  overwriteEvent?: boolean;
   errorResponse?: (
     statusCode: number,
     message: string,
@@ -40,6 +41,9 @@ export const zodValidator = (opts: Inputs = {}) => {
           "Event failed validation",
           eventValidation?.error
         );
+      }
+      if (eventValidation?.success && opts.overwriteEvent) {
+        input.event = eventValidation.data;
       }
       const contextValidation = opts.contextSchema?.safeParse(input.context);
       if (contextValidation && !contextValidation?.success) {


### PR DESCRIPTION
When developing some lambdas, we found it useful to declare some defaults directly on the schema. However, currently the library does not allow overwriting the event with the validation result.

This may be applied to ENV as well (so to have defaults on environment variables).

PS: I did not find a better name for the parameter, sorry :D 