### PR TITLE
feature: adds the ability to write the result of environment variable validation to context.env

### DIFF
--- a/packages/middy-zod-validator/README.md
+++ b/packages/middy-zod-validator/README.md
@@ -124,6 +124,21 @@ export const handler = middy(lambdaFunction).use(
 );
 ```
 
+Optionally, you can write the results of environment variable validation to `context.env`. This way you can apply default values ​​to environment variables.
+
+```ts
+const envSchema: z.object({
+	YOUR_ENV: z.string().default("DefaultValue"),
+}),
+
+export const handler = middy(lambdaFunction).use(
+  zodValidator({
+    envSchema,
+    setEnvToContext: true,
+  })
+);
+```
+
 ## Contribution
 
 If there is an option or feature you would like to see, please feel free to raise an issue or open a pull request. Contributions are welcome :)

--- a/packages/middy-zod-validator/src/index.test.ts
+++ b/packages/middy-zod-validator/src/index.test.ts
@@ -1,4 +1,4 @@
-import { ZodSchema } from "zod";
+import { z, ZodSchema } from "zod";
 import { zodValidator } from ".";
 
 beforeEach(() => {
@@ -62,10 +62,13 @@ describe("When the zodValidator is called", () => {
     });
   });
 
-
   it("should overwrite when the appropriate option is set", async () => {
     const input = {
-      eventSchema: { safeParse: jest.fn().mockReturnValue({ success: true, data: { my: "event" } }) } as unknown as ZodSchema,
+      eventSchema: {
+        safeParse: jest
+          .fn()
+          .mockReturnValue({ success: true, data: { my: "event" } }),
+      } as unknown as ZodSchema,
       overwriteEvent: true,
     };
     const result = zodValidator(input);
@@ -74,6 +77,166 @@ describe("When the zodValidator is called", () => {
     await result.before(beforeInput);
 
     expect(input.eventSchema.safeParse).toHaveBeenCalledWith("MOCK_EVENT");
-    expect(beforeInput.event).toEqual( { my: "event" });
+    expect(beforeInput.event).toEqual({ my: "event" });
+  });
+
+  it("should write env to context if the appropriate option is set", async () => {
+    const input = {
+      envSchema: z.object({
+        MY_MOCK_TEST_ENV: z.string().default("MOCK"),
+      }),
+      setEnvToContext: true,
+    };
+    const result = zodValidator(input);
+
+    const beforeInput: { event: any; context: any } = {
+      event: "MOCK_EVENT",
+      context: {},
+    };
+    await result.before(beforeInput);
+
+    expect(beforeInput.context.env).toEqual({ MY_MOCK_TEST_ENV: "MOCK" });
+  });
+
+  it("should write env to context if the appropriate option is set with context null", async () => {
+    const input = {
+      envSchema: z.object({
+        MY_MOCK_TEST_ENV: z.string().default("MOCK"),
+      }),
+      setEnvToContext: true,
+    };
+    const result = zodValidator(input);
+
+    const beforeInput: { event: any; context: any } = {
+      event: "MOCK_EVENT",
+      context: null,
+    };
+    await result.before(beforeInput);
+
+    expect(beforeInput.context.env).toEqual({ MY_MOCK_TEST_ENV: "MOCK" });
+  });
+
+  it("should not overwrite other context values when setEnvToContext is set", async () => {
+    const input = {
+      envSchema: z.object({
+        MY_MOCK_TEST_ENV: z.string().default("MOCK"),
+      }),
+      setEnvToContext: true,
+    };
+    const result = zodValidator(input);
+    const mockContext = { other: "values", env: { additional: "envs" } };
+    const beforeInput: { event: any; context: any } = {
+      event: "MOCK_EVENT",
+      context: mockContext,
+    };
+    await result.before(beforeInput);
+
+    expect(beforeInput.context).toEqual({
+      ...mockContext,
+      env: { ...mockContext.env, MY_MOCK_TEST_ENV: "MOCK" },
+    });
+  });
+
+  it("should call errorResponse if contextValidation fails", async () => {
+    const input = {
+      contextSchema: {
+        safeParse: jest
+          .fn()
+          .mockReturnValue({ success: false, error: "Invalid" }),
+      } as unknown as ZodSchema,
+      logger: {
+        error: jest.fn(),
+      },
+    };
+
+    const result = zodValidator(input);
+
+    const beforeInput = { event: "MOCK_EVENT", context: "MOCK_CONTEXT" };
+    const res = await result.before(beforeInput);
+    expect(input.logger.error).toHaveBeenCalled();
+    expect(res).toStrictEqual({
+      statusCode: 400,
+      body: JSON.stringify({
+        message: "Context failed validation",
+        error: "Invalid",
+      }),
+    });
+  });
+
+  it("should call errorResponse provided if validation fails", async () => {
+    const input = {
+      contextSchema: {
+        safeParse: jest
+          .fn()
+          .mockReturnValue({ success: false, error: "Invalid" }),
+      } as unknown as ZodSchema,
+      logger: {
+        error: jest.fn(),
+      },
+      errorResponse: jest.fn(),
+    };
+
+    const result = zodValidator(input);
+
+    const beforeInput = { event: "MOCK_EVENT", context: "MOCK_CONTEXT" };
+    await result.before(beforeInput);
+    expect(input.logger.error).toHaveBeenCalledTimes(0);
+    expect(input.errorResponse).toHaveBeenCalledWith(
+      400,
+      "Context failed validation",
+      "Invalid"
+    );
+  });
+
+  it("should call errorResponse if envValidation fails", async () => {
+    const input = {
+      envSchema: {
+        safeParse: jest
+          .fn()
+          .mockReturnValue({ success: false, error: "Invalid" }),
+      } as unknown as ZodSchema,
+      logger: {
+        error: jest.fn(),
+      },
+    };
+
+    const result = zodValidator(input);
+
+    const beforeInput = { event: "MOCK_EVENT", context: "MOCK_CONTEXT" };
+    const res = await result.before(beforeInput);
+    expect(input.logger.error).toHaveBeenCalled();
+    expect(res).toStrictEqual({
+      statusCode: 400,
+      body: JSON.stringify({
+        message: "Environment failed validation",
+        error: "Invalid",
+      }),
+    });
+  });
+
+  it("should call errorResponse if responseValidation fails", async () => {
+    const input = {
+      responseSchema: {
+        safeParse: jest
+          .fn()
+          .mockReturnValue({ success: false, error: "Invalid" }),
+      } as unknown as ZodSchema,
+      logger: {
+        error: jest.fn(),
+      },
+    };
+
+    const result = zodValidator(input);
+
+    const afterInput = { response: "MOCK_RESPONSE" };
+    const res = await result.after(afterInput);
+    expect(input.logger.error).toHaveBeenCalled();
+    expect(res).toStrictEqual({
+      statusCode: 400,
+      body: JSON.stringify({
+        message: "Environment failed validation",
+        error: "Invalid",
+      }),
+    });
   });
 });

--- a/packages/middy-zod-validator/src/index.ts
+++ b/packages/middy-zod-validator/src/index.ts
@@ -1,4 +1,4 @@
-import { ZodError, ZodSchema } from "zod";
+import { object, ZodError, ZodSchema } from "zod";
 
 // Overwrite keys on a target T with keys in the source S
 // Useful for extending an AWS type after manipulation by middy
@@ -11,6 +11,7 @@ type Inputs = {
   envSchema?: ZodSchema;
   logger?: any;
   overwriteEvent?: boolean;
+  setEnvToContext?: boolean;
   errorResponse?: (
     statusCode: number,
     message: string,
@@ -31,6 +32,7 @@ export const zodValidator = (opts: Inputs = {}) => {
         body: JSON.stringify({ message, error: error?.issues ?? error }),
       };
     });
+  const envValidation = opts.envSchema?.safeParse(process.env);
 
   return {
     before: async (input: { event: unknown; context: unknown }) => {
@@ -53,12 +55,23 @@ export const zodValidator = (opts: Inputs = {}) => {
           contextValidation?.error
         );
       }
-      const envValidation = opts.envSchema?.safeParse(process.env);
       if (envValidation && !envValidation?.success) {
         return errorResponse(
           400,
           "Environment failed validation",
           envValidation?.error
+        );
+      }
+
+      if (
+        envValidation?.success &&
+        opts.setEnvToContext &&
+        typeof input.context === "object"
+      ) {
+        Object.assign(
+          (((input.context ??= {}) as { env?: Record<string, any> }).env ??=
+            {}),
+          envValidation.data
         );
       }
     },

--- a/packages/middy-zod-validator/src/index.ts
+++ b/packages/middy-zod-validator/src/index.ts
@@ -1,4 +1,4 @@
-import { object, ZodError, ZodSchema } from "zod";
+import { ZodError, ZodSchema } from "zod";
 
 // Overwrite keys on a target T with keys in the source S
 // Useful for extending an AWS type after manipulation by middy


### PR DESCRIPTION
similarly to what was done for the eventSchema, it would be nice to have the ability to write environment variables with the validation result in context.env.

I also moved the environment variable parsing out of the before function so it doesn't have to be executed on every request.